### PR TITLE
Fix a typo in the word tailwind in index.css

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,4 @@
-@layer talwind {
+@layer tailwind {
   @tailwind base;
 }
 @tailwind components;


### PR DESCRIPTION
The layer name had a typo in the word tailwind. 
I don't think it was intentional as the code works fine even when the typo is fixed. So adding a PR for that. Great work on the repo btw 🥳